### PR TITLE
gap-packages Ownership Update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Thank you for contributing to this project! You must fill out the information be
 Closes [issue link]
 
 <!-- If there's an existing issue for your change, please link to it in the brackets above.
-If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/ZachNewbery/typeset/new/choose. -->
+If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/gap-packages/typeset/new/choose. -->
 
 ### What's being changed (if available, include any code snippets, screenshots, or gifs):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ Welcome! To get an overview of the package, read the [README](README.md). Here a
 
 #### Create a new issue
 
-If you spot a problem or find something you want to add, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue doesn't exist, you can open a [new issue](https://github.com/ZachNewbery/typeset/issues/new). 
+If you spot a problem or find something you want to add, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue doesn't exist, you can open a [new issue](https://github.com/gap-packages/typeset/issues/new). 
 
 #### Solve an issue
 
-Scan through the [existing issues](https://github.com/ZachNewbery/typeset/issues) to find one that interests you. You can narrow down the search using `labels` as filters. See [Labels](https://github.com/ZachNewbery/typeset/labels) for more information. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+Scan through the [existing issues](https://github.com/gap-packages/typeset/issues) to find one that interests you. You can narrow down the search using `labels` as filters. See [Labels](https://github.com/gap-packages/typeset/labels) for more information. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
 
 ### Types of Contributions
 
@@ -42,7 +42,7 @@ First, it is best to create a new directory named after the language within the 
 
 Within this directory, you'll want to have at least two files, a _lang_.gd and a _lang_.gi. These files will follow the typical layout for GAP declaration and implementation files, and will contain the language-specific functions for your new implementation.
 
-Once your files have been created, the next step will be implementing the operation to generate template strings for your language. As described in the [documentation](http://ZachNewbery.github.io/typeset/doc/chap1_mj.html), the framework works by calling language-specific functions to generate language-specific template strings followed by populating them with a language-agnostic list of semantic features pertaining to the GAP object being typeset. 
+Once your files have been created, the next step will be implementing the operation to generate template strings for your language. As described in the [documentation](http://gap-packages.github.io/typeset/doc/chap1_mj.html), the framework works by calling language-specific functions to generate language-specific template strings followed by populating them with a language-agnostic list of semantic features pertaining to the GAP object being typeset. 
 
 Therefore, you'll want to implement a method of the name Gen<em>Lang</em>Tmpl (only the first letter of the language should be capitalised) for any and all of the types you're looking to typeset. It may also be a good idea to have a default fallback to the core GAP method `String`, as many objects may not even need any specific changes to get them typeset!
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -30,10 +30,10 @@ Persons := [
 
 SourceRepository := rec(
     Type := "git",
-    URL := "https://github.com/ZachNewbery/typeset",
+    URL := "https://github.com/gap-packages/typeset",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://ZachNewbery.github.io/typeset/",
+PackageWWWHome  := "https://gap-packages.github.io/typeset/",
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 README_URL      := Concatenation( ~.PackageWWWHome, "README.md" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://github.com/ZachNewbery/typeset/workflows/CI/badge.svg?branch=main)](https://github.com/ZachNewbery/typeset/actions?query=workflow%3ACI+branch%3Amain)
-[![Code Coverage](https://codecov.io/gh/ZachNewbery/typeset/branch/main/graph/badge.svg?token=8M7DUY6DWT)](https://codecov.io/gh/ZachNewbery/typeset)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ZachNewbery/typeset/HEAD)
+[![Build Status](https://github.com/gap-packages/typeset/workflows/CI/badge.svg?branch=main)](https://github.com/gap-packages/typeset/actions?query=workflow%3ACI+branch%3Amain)
+[![Code Coverage](https://codecov.io/github/gap-packages/typeset/coverage.svg?branch=main&token=)](https://codecov.io/gh/gap-packages/typeset)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gap-packages/typeset/HEAD)
 
 # The typeset GAP package
 This package implements a framework for automatic typesetting of common GAP objects, 
@@ -26,7 +25,7 @@ the package as per normal.
 Full information and documentation can be found in the manual, available
 as a [PDF](doc/manual.pdf) or as HTML on the package homepage at
 
-<https://ZachNewbery.github.io/typeset>
+<https://gap-packages.github.io/typeset>
 
 Added features for each version of the package are also tracked in the [changelog](CHANGELOG.md).
 
@@ -42,7 +41,7 @@ the [contributing guide](CONTRIBUTING.md). All help is greatly appreciated!
 If you have any questions, or just want some off-topic discussion, check out the
 discussions area of the repository:
 
-  <https://github.com/ZachNewbery/typeset/discussions>
+  <https://github.com/gap-packages/typeset/discussions>
 
 This is the place to go if you have any new ideas you want to flesh out before
 committing to writing out an issue or are having any problems you think might not 
@@ -51,7 +50,7 @@ be a bug!
 ## Bug Reports and Feature Requests
 Please submit bug reports and feature requests via the GitHub issue tracker:
 
-  <https://github.com/ZachNewbery/typeset/issues>
+  <https://github.com/gap-packages/typeset/issues>
 
 # License
 typeset is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This PR looks to change any instances relevant to my GitHub account to gap-packages. It is to be merged when ownership can be transferred to gap-packages. 

It is essentially a replica of the reverted PR #14, and is to be merged after submission of my dissertation in January.
